### PR TITLE
persistent volume claim implementaion

### DIFF
--- a/k8s-manifests/postgres-deployment.yaml
+++ b/k8s-manifests/postgres-deployment.yaml
@@ -37,8 +37,9 @@ spec:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
       volumes:
-        - name: postgres-data
-          emptyDir: {}  # Use a PVC here for persistence
+        - name: postgres-data # name for this volume inside the pod
+          persistentVolumeClaim:
+            claimName: postgres-pvc # name of the PVC created in postgres-pvc.yaml
 ---
 apiVersion: v1
 kind: Service

--- a/k8s-manifests/postgres-pvc.yaml
+++ b/k8s-manifests/postgres-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc 
+spec:
+  # accessModes determines how the volume can be mounted.
+  # ReadWriteOnce means it can be mounted as read-write by a single Node.
+  # This is perfect for a single-replica database.
+  accessModes:
+    - ReadWriteOnce
+  # resources.requests.storage is how much disk space we are requesting.
+  resources:
+    requests:
+      storage: 1Gi 


### PR DESCRIPTION
Implemented the PVC (persistent Volume Claim). I restarted the postgres-deployment manifest and exec into the container and prooved that the volume is persistent. The database files including the test table i created survived the pod restart.