### PR TITLE
resource request and limits to control usage

### DIFF
--- a/k8s-manifests/fastapi-deployment.yaml
+++ b/k8s-manifests/fastapi-deployment.yaml
@@ -17,6 +17,13 @@ spec:
           image: akaehomen321/time-api-app:main
           ports:
             - containerPort: 8000
+          resources:
+            requests:
+              cpu: "100m"      # Request 1/10th of a CPU core
+              memory: "128Mi"  # Request 128 Mebibytes of RAM
+            limits:
+              cpu: "250m"      # Limit to 1/4th of a CPU core
+              memory: "256Mi"  # Limit to 256 Mebibytes of RAM  
           env:
             - name: POSTGRES_USER
               valueFrom:

--- a/k8s-manifests/postgres-deployment.yaml
+++ b/k8s-manifests/postgres-deployment.yaml
@@ -17,6 +17,13 @@ spec:
           image: postgres:13
           ports:
             - containerPort: 5432
+          resources:
+            requests:
+              cpu: "250m"      # Request 1/10th of a CPU core
+              memory: "256Mi"  # Request 128 Mebibytes of RAM
+            limits:
+              cpu: "500m"      # Limit to 1/4th of a CPU core
+              memory: "512Mi"  # Limit to 256 Mebibytes of RAM
           env:
             - name: POSTGRES_USER
               valueFrom:


### PR DESCRIPTION
Setting resource requests and limits to run stable, predictable, and efficient Kubernetes clusters. Your FastAPI application is likely not very resource-intensive. It's mostly I/O bound (waiting for the database). i started with some small, reasonable values.However the Database are generally more resource-hungry, especially with memory, as they use it for caching to speed up queries. So i gave it more resources than the fastapi App.